### PR TITLE
Yell (nicely) about python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import sys
 
 from setuptools import setup


### PR DESCRIPTION
```shell-session
$ python --version
Python 2.7.16
$ python setup.py install
ERROR: fuzzbucket-client requires python 3.5+
This python is:
2.7.16 (default, Dec 13 2019, 18:00:32)
[GCC 4.2.1 Compatible Apple LLVM 11.0.0 (clang-1100.0.32.4) (-macos10.15-objc-s
$ echo $?
86
```