### PR TITLE
Update serverless.yml

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -192,6 +192,11 @@ resources:
           FromPort: 8443
           IpProtocol: tcp
           ToPort: 8443
+        - CidrIp: 0.0.0.0/0
+          Description: allow vnc network traffic 
+          FromPort: 5900
+          IpProtocol: tcp
+          ToPort: 5900
         Tags:
         - Key: Name
           Value: fuzzbucket-${opt:stage, 'dev'}-default-sg


### PR DESCRIPTION
Added port 5900 for vnc viewer access to servers. This change accommodates the ide team's configuration updates that add an option to deploy RStudio Desktop to fuzzbucket instances.