### PR TITLE
Allow naming of credentials sections

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,3 +1,5 @@
+set shell := ["bash", "-c"]
+
 fuzzbucket_version := `pipenv run python setup.py --version 2>/dev/null || echo 0.0.0`
 fuzzbucket_release_artifact := 'dist/fuzzbucket_client-' + fuzzbucket_version + '-py3-none-any.whl'
 fuzzbucket_s3_prefix := 's3://rstudio-connect-downloads/connect/fuzzbucket'


### PR DESCRIPTION
Closes #79

The net result is the same as if the `~/.cache/fuzzbucket/credentials` file had been edited manually, but at least this capability has more of a "supported feature" feel to it 😂 .

Caveat: Any name given at `login` time will be retained as long as there is a matching `server` section in the credentials file.