### PR TITLE
add rocky, alma, amzn default ssh users

### DIFF
--- a/fuzzbucket_client/__main__.py
+++ b/fuzzbucket_client/__main__.py
@@ -620,9 +620,12 @@ class Client:
     default_ssh_user = "ec2-user"
     default_ssh_users = {
         "centos": "centos",
+        "rocky": "rocky",
         "rhel": default_ssh_user,
         "sles": default_ssh_user,
         "suse": default_ssh_user,
+        "almalinux": default_ssh_user,
+        "amzn": default_ssh_user,
         "ubuntu": "ubuntu",
     }
 


### PR DESCRIPTION
Distribution tests in Connect use `fuzzbucket-client` and we are adding several new distros to support: https://github.com/rstudio/connect/pull/20507

`fuzzbucket ssh` needs to use the correct users. 

New distro support tracking issue: https://github.com/rstudio/connect/issues/20107 and https://github.com/rstudio/connect/issues/19660