### PR TITLE
Ensure the reap function also has AWSLambdaPowertoolsPythonV2 layer

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -66,6 +66,7 @@ functions:
 
     layers:
     - Ref: PythonRequirementsLambdaLayer
+    - arn:aws:lambda:${self:provider.environment.FUZZBUCKET_REGION}:017000801446:layer:AWSLambdaPowertoolsPythonV2:51
 
     events:
     - schedule: rate(10 minutes)


### PR DESCRIPTION
so that attempting to import `aws_lambda_powertools` doesn't result in `ImportError`