### PR TITLE
Resize/renumber the default VPC CidrBlocks

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -73,7 +73,7 @@ def env_setup():
 def dynamodb(fake_users, monkeypatch):
     from fuzzbucket import aws
 
-    with moto.mock_dynamodb():
+    with moto.mock_aws():
         ddb = boto3.resource("dynamodb", region_name="us-east-1")
         setup_dynamodb_tables(ddb, fake_users)
 
@@ -87,7 +87,7 @@ def dynamodb(fake_users, monkeypatch):
 def ec2(monkeypatch):
     from fuzzbucket import aws
 
-    with moto.mock_ec2():
+    with moto.mock_aws():
         ec2c = boto3.client("ec2", region_name="us-east-1")
 
         with monkeypatch.context() as mp:

--- a/default-resources.yml
+++ b/default-resources.yml
@@ -3,7 +3,7 @@ resources:
     VPC:
       Type: AWS::EC2::VPC
       Properties:
-        CidrBlock: 172.98.0.0/18
+        CidrBlock: 172.22.0.0/20
         EnableDnsSupport: true
         EnableDnsHostnames: true
         Tags:
@@ -15,7 +15,7 @@ resources:
       Properties:
         VpcId: !Ref VPC
         AvailabilityZone: ${aws:region, 'us-east-1'}a
-        CidrBlock: 172.98.0.0/18
+        CidrBlock: 172.22.0.0/20
         MapPublicIpOnLaunch: true
         Tags:
         - Key: Name

--- a/fuzzbucket/__init__.py
+++ b/fuzzbucket/__init__.py
@@ -8,7 +8,7 @@ from . import aws
 
 def deferred_app(
     environ: dict[str, str], start_response: typing.Callable
-) -> typing.Iterable[str]:
+) -> typing.Iterable[bytes]:
     return cached_app()(environ, start_response)
 
 

--- a/fuzzbucket/g.py
+++ b/fuzzbucket/g.py
@@ -7,10 +7,10 @@ oauth_blueprint: werkzeug.local.LocalProxy[
     flask_dance.consumer.OAuth2ConsumerBlueprint
 ] = werkzeug.local.LocalProxy(auth.get_oauth_blueprint)
 
-oauth_session: werkzeug.local.LocalProxy[
-    flask_dance.consumer.OAuth2Session
-] = werkzeug.local.LocalProxy(lambda: auth.get_oauth_blueprint().session)
+oauth_session: werkzeug.local.LocalProxy[flask_dance.consumer.OAuth2Session] = (
+    werkzeug.local.LocalProxy(lambda: auth.get_oauth_blueprint().session)
+)
 
-user_storage: werkzeug.local.LocalProxy[
-    flask_dance_storage.FlaskDanceStorage
-] = werkzeug.local.LocalProxy(flask_dance_storage.get_storage)
+user_storage: werkzeug.local.LocalProxy[flask_dance_storage.FlaskDanceStorage] = (
+    werkzeug.local.LocalProxy(flask_dance_storage.get_storage)
+)

--- a/fuzzbucket_client/__main__.py
+++ b/fuzzbucket_client/__main__.py
@@ -141,8 +141,7 @@ log = logging.getLogger("fuzzbucket")
 
 class CustomHelpFormatter(
     argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter
-):
-    ...
+): ...
 
 
 def main(sysargs: list[str] = sys.argv[:]) -> int:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,8 @@ addopts = '''
   --cov-report term
   --cov-report html
   --cov-report xml
+  --ignore=wsgi_handler.py
+  --ignore=serverless_wsgi.py
   -vv
   --mypy
   --disable-warnings


### PR DESCRIPTION
Fixes #137

Also avoid 172.17.0.0/16 block used by AWS Cloud9 and SageMaker per https://docs.aws.amazon.com/vpc/latest/userguide/vpc-cidr-blocks.html

I think to pick up this change folks might need to tear down/redeploy their fuzzbucket deployment?