### PR TITLE
Provide github oauth scope as comma-delimited string

### DIFF
--- a/fuzzbucket/blueprints/github_oauth.py
+++ b/fuzzbucket/blueprints/github_oauth.py
@@ -12,7 +12,7 @@ from ..log import log
 storage = flask_dance_storage.FlaskDanceStorage(table_name=cfg.USERS_TABLE)
 
 bp = flask_dance.contrib.github.make_github_blueprint(
-    scope=["read:org", "read:public_key"],
+    scope="read:org,read:public_key",
     redirect_to="github.auth_complete",
     storage=storage,
 )


### PR DESCRIPTION
as indicated by [the docs](https://flask-dance.readthedocs.io/en/latest/providers.html#module-flask_dance.contrib.github) and the mismatched scope errors we're now seeing.